### PR TITLE
Fix Gem drop

### DIFF
--- a/alexndr/SimpleOres/api/content/SimpleOre.java
+++ b/alexndr/SimpleOres/api/content/SimpleOre.java
@@ -90,11 +90,7 @@ public class SimpleOre extends Block
 	{
 		if(stackDrop != null)
 		{
-			if(stackDrop.itemID > 4095)
-			{
-				return stackDrop.itemID + 256;
-			}
-			else return stackDrop.itemID;
+			return stackDrop.itemID;
 
 		}
 		else return this.blockID;


### PR DESCRIPTION
"return stackDrop.itemID + 256;" is not needed when using itemID rather than the config setting.
